### PR TITLE
fix: use consistent dependency group names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dynamic = ["version"]
 
 
 [project.optional-dependencies]
-test = ["pytest", "pytest-cov","pytest-benchmark"]
+tests = ["pytest", "pytest-cov","pytest-benchmark"]
 dev = ["pre-commit", "ruff==0.2.0"]
 
 docs = [


### PR DESCRIPTION
Changed 'test' to 'tests' to match README
This ensures that python3 -m pip install -e '.[dev,tests]' works as intended