### PR TITLE
build: add version definition 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,7 @@
 [project]
 name = "dgipy"
 authors = [
-
     {name = "Matthew Cannon", email = "Matthew.Cannon2@nationwidechildrens.org"},
-
 ]
 readme = "README.md"
 classifiers = [
@@ -24,8 +22,6 @@ description = "Python wrapper for accessing an instance of DGIdb v5 database"
 license = {file = "LICENSE"}
 dependencies = []
 dynamic = ["version"]
-
-
 
 [project.optional-dependencies]
 test = ["pytest", "pytest-cov","pytest-benchmark"]
@@ -55,6 +51,9 @@ Source = "https://github.com/genomicmedlab/dgipy"
 [build-system]
 requires = ["setuptools>=64", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools.dynamic]
+version = {attr = "dgipy.version.__version__"}
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dynamic = ["version"]
 [project.optional-dependencies]
 test = ["pytest", "pytest-cov","pytest-benchmark"]
 dev = ["pre-commit", "ruff==0.2.0"]
-
 docs = [
     "sphinx==6.1.3",
     "sphinx-autodoc-typehints==1.22.0",
@@ -37,7 +36,6 @@ docs = [
     "gravis==0.1.0",
     "sphinx-github-changelog==1.2.1"
 ]
-
 
 [project.urls]
 Homepage = "https://github.com/genomicmedlab/dgipy"

--- a/src/dgipy/version.py
+++ b/src/dgipy/version.py
@@ -1,2 +1,2 @@
 """Define package version."""
-___version__ = "0.1.0"
+__version__ = "0.1.0"

--- a/src/dgipy/version.py
+++ b/src/dgipy/version.py
@@ -1,0 +1,2 @@
+"""Define package version."""
+___version__ = "0.1.0"


### PR DESCRIPTION
This was a deficiency of the original lab software template. There are probably better ways to set a version that we could potentially switch to later, but this is the simplest one: setting a version variable in a specific module.