### PR TITLE
chore: make type annotations backward compatible

### DIFF
--- a/src/dgipy/dgidb.py
+++ b/src/dgipy/dgidb.py
@@ -21,12 +21,12 @@ def _get_client(api_url: str) -> Client:
 
 
 def get_drug(
-    terms: list | str,
+    terms: Union[List, str],
     use_pandas: bool = True,
     immunotherapy: Optional[bool] = None,
     antineoplastic: Optional[bool] = None,
     api_url: Optional[str] = None,
-) -> pd.DataFrame | dict:
+) -> Union[pd.DataFrame, Dict]:
     """Perform a record look up in DGIdb for a drug of interest
 
     :param terms: drug or drugs for record lookup
@@ -90,8 +90,8 @@ def get_drug(
 
 
 def get_gene(
-    terms: list | str, use_pandas: bool = True, api_url: Optional[str] = None
-) -> pd.DataFrame | dict:
+    terms: Union[List, str], use_pandas: bool = True, api_url: Optional[str] = None
+) -> Union[pd.DataFrame, Dict]:
     """Perform a record look up in DGIdb for a gene of interest
 
     :param terms: gene or genes for record lookup
@@ -132,17 +132,17 @@ def get_gene(
 
 
 def get_interactions(
-    terms: list | str,
+    terms: Union[List, str],
     search: str = "genes",
     use_pandas: bool = True,
     immunotherapy: Optional[bool] = None,
     antineoplastic: Optional[bool] = None,
-    source: str | None = None,
+    source: Optional[str] = None,
     pmid: Optional[int] = None,
-    interaction_type: str | None = None,
-    approved: str | None = None,
+    interaction_type: Optional[str] = None,
+    approved: Optional[str] = None,
     api_url: Optional[str] = None,
-) -> pd.DataFrame | dict:
+) -> Union[pd.DataFrame, Dict]:
     """Perform an interaction look up for drugs or genes of interest
 
     :param terms: drugs or genes for interaction look up
@@ -270,8 +270,8 @@ def get_interactions(
 
 
 def get_categories(
-    terms: list | str, use_pandas: bool = True, api_url: Optional[str] = None
-) -> pd.DataFrame | dict:
+    terms: Union[List, str], use_pandas: bool = True, api_url: Optional[str] = None
+) -> Union[pd.DataFrame, Dict]:
     """Perform a category annotation lookup for genes of interest
 
     :param terms: Genes of interest for annotations
@@ -307,7 +307,7 @@ def get_categories(
     return result
 
 
-def get_source(search: str = "all", api_url: Optional[str] = None) -> dict:
+def get_source(search: str = "all", api_url: Optional[str] = None) -> Dict:
     """Perform a source lookup for relevant aggregate sources
 
     :param search: string to denote type of source to lookup
@@ -341,7 +341,7 @@ def get_source(search: str = "all", api_url: Optional[str] = None) -> dict:
     return client.execute(query, variable_values=params)
 
 
-def get_gene_list(api_url: Optional[str] = None) -> list:
+def get_gene_list(api_url: Optional[str] = None) -> List:
     """Get all gene names present in DGIdb
 
     :param api_url: API endpoint for GraphQL request
@@ -368,8 +368,8 @@ def get_gene_list(api_url: Optional[str] = None) -> list:
 
 
 def get_drug_applications(
-    terms: list | str, use_pandas: bool = True, api_url: Optional[str] = None
-) -> pd.DataFrame | dict:
+    terms: Union[List, str], use_pandas: bool = True, api_url: Optional[str] = None
+) -> Union[pd.DataFrame, Dict]:
     """Perform a look up for ANDA/NDA applications for drug or drugs of interest
 
     :param terms: drug or drugs of interest
@@ -404,7 +404,7 @@ def get_drug_applications(
     return result
 
 
-def __process_drug(results: dict) -> pd.DataFrame:
+def __process_drug(results: Dict) -> pd.DataFrame:
     drug_list = []
     concept_list = []
     alias_list = []
@@ -449,7 +449,7 @@ def __process_drug(results: dict) -> pd.DataFrame:
     )
 
 
-def __process_gene(results: dict) -> pd.DataFrame:
+def __process_gene(results: Dict) -> pd.DataFrame:
     gene_list = []
     alias_list = []
     concept_list = []
@@ -473,7 +473,7 @@ def __process_gene(results: dict) -> pd.DataFrame:
     )
 
 
-def __process_gene_search(results: dict) -> pd.DataFrame:
+def __process_gene_search(results: Dict) -> pd.DataFrame:
     interactionscore_list = []
     drugname_list = []
     approval_list = []
@@ -530,7 +530,7 @@ def __process_gene_search(results: dict) -> pd.DataFrame:
     )
 
 
-def __process_gene_categories(results: dict) -> pd.DataFrame:
+def __process_gene_categories(results: Dict) -> pd.DataFrame:
     gene_list = []
     categories_list = []
     sources_list = []
@@ -554,7 +554,7 @@ def __process_gene_categories(results: dict) -> pd.DataFrame:
     )
 
 
-def __process_drug_search(results: dict) -> pd.DataFrame:
+def __process_drug_search(results: Dict) -> pd.DataFrame:
     interactionscore_list = []
     genename_list = []
     approval_list = []
@@ -601,7 +601,7 @@ def __process_drug_search(results: dict) -> pd.DataFrame:
     )
 
 
-def __process_drug_applications(data: dict) -> pd.DataFrame:
+def __process_drug_applications(data: Dict) -> pd.DataFrame:
     drug_list = []
     application_list = []
 

--- a/src/dgipy/graph_app.py
+++ b/src/dgipy/graph_app.py
@@ -1,4 +1,5 @@
 """Provides functionality to create a Dash web application for interacting with drug-gene data from DGIdb"""
+from typing import List, Union, Tuple, Dict, Optional
 import dash_bootstrap_components as dbc
 from dash import Input, Output, State, ctx, dash, dcc, html
 
@@ -25,7 +26,7 @@ def generate_app() -> dash.Dash:
     return app
 
 
-def __set_app_layout(app: dash.Dash, plot: ng.go.Figure, genes: list) -> None:
+def __set_app_layout(app: dash.Dash, plot: ng.go.Figure, genes: List) -> None:
     graph_display = dcc.Graph(
         id="network-graph", figure=plot, style={"width": "100%", "height": "800px"}
     )
@@ -97,7 +98,7 @@ def __update_plot(app: dash.Dash) -> None:
         [Output("graph", "data"), Output("network-graph", "figure")],
         Input("gene-dropdown", "value"),
     )
-    def update(selected_genes: None | list) -> tuple[dict | None, ng.go.Figure]:
+    def update(selected_genes: Optional[List]) -> Tuple[Union[Dict, None], ng.go.Figure]:
         if selected_genes is not None:
             gene_interactions = dgidb.get_interactions(selected_genes)
             updated_graph = ng.create_network(gene_interactions, selected_genes)
@@ -111,7 +112,7 @@ def __update_selected_node(app: dash.Dash) -> None:
         Output("selected-node", "data"),
         [Input("network-graph", "click_data"), Input("gene-dropdown", "value")],
     )
-    def update(click_data: None | dict, new_gene: None | list) -> str | dict:
+    def update(click_data: Optional[Dict], new_gene: Optional[List]) -> Union[str, Dict]:
         if ctx.triggered_id == "gene-dropdown":
             return ""
         if click_data is not None and "points" in click_data:
@@ -126,7 +127,7 @@ def __update_selected_node_display(app: dash.Dash) -> None:
     @app.callback(
         Output("selected-node-text", "children"), Input("selected-node", "data")
     )
-    def update(selected_node: str | dict) -> str:
+    def update(selected_node: Union[str, Dict]) -> str:
         if selected_node != "":
             return selected_node["text"]
         return "No Node Selected"
@@ -137,7 +138,7 @@ def __update_neighbor_dropdown(app: dash.Dash) -> None:
         [Output("neighbor-dropdown", "options"), Output("neighbor-dropdown", "value")],
         Input("selected-node", "data"),
     )
-    def update(selected_node: str | dict) -> tuple[list, None]:
+    def update(selected_node: Union[str, Dict]) -> Tuple[List, None]:
         if selected_node != "" and selected_node["curveNumber"] != 1:
             return selected_node["customdata"], None
         return [], None
@@ -150,7 +151,7 @@ def __update_edge_info(app: dash.Dash) -> None:
         State("graph", "data"),
     )
     def update(
-        selected_node: str | dict, selected_neighbor: None | str, graph: None | dict
+        selected_node: Union[str, Dict], selected_neighbor: Optional[str], graph: Optional[Dict]
     ) -> str:
         if selected_node == "":
             return "No Edge Selected"
@@ -206,7 +207,7 @@ def __update_edge_info(app: dash.Dash) -> None:
         return "No Edge Selected"
 
 
-def __get_node_data_from_id(nodes: list, node_id: str) -> dict | None:
+def __get_node_data_from_id(nodes: List, node_id: str) -> Optional[Dict]:
     for node in nodes:
         if node["id"] == node_id:
             return node

--- a/src/dgipy/graph_app.py
+++ b/src/dgipy/graph_app.py
@@ -1,5 +1,6 @@
 """Provides functionality to create a Dash web application for interacting with drug-gene data from DGIdb"""
-from typing import List, Union, Tuple, Dict, Optional
+from typing import Dict, List, Optional, Tuple, Union
+
 import dash_bootstrap_components as dbc
 from dash import Input, Output, State, ctx, dash, dcc, html
 
@@ -98,7 +99,9 @@ def __update_plot(app: dash.Dash) -> None:
         [Output("graph", "data"), Output("network-graph", "figure")],
         Input("gene-dropdown", "value"),
     )
-    def update(selected_genes: Optional[List]) -> Tuple[Union[Dict, None], ng.go.Figure]:
+    def update(
+        selected_genes: Optional[List],
+    ) -> Tuple[Union[Dict, None], ng.go.Figure]:
         if selected_genes is not None:
             gene_interactions = dgidb.get_interactions(selected_genes)
             updated_graph = ng.create_network(gene_interactions, selected_genes)
@@ -112,7 +115,9 @@ def __update_selected_node(app: dash.Dash) -> None:
         Output("selected-node", "data"),
         [Input("network-graph", "click_data"), Input("gene-dropdown", "value")],
     )
-    def update(click_data: Optional[Dict], new_gene: Optional[List]) -> Union[str, Dict]:
+    def update(
+        click_data: Optional[Dict], new_gene: Optional[List]
+    ) -> Union[str, Dict]:
         if ctx.triggered_id == "gene-dropdown":
             return ""
         if click_data is not None and "points" in click_data:
@@ -151,7 +156,9 @@ def __update_edge_info(app: dash.Dash) -> None:
         State("graph", "data"),
     )
     def update(
-        selected_node: Union[str, Dict], selected_neighbor: Optional[str], graph: Optional[Dict]
+        selected_node: Union[str, Dict],
+        selected_neighbor: Optional[str],
+        graph: Optional[Dict],
     ) -> str:
         if selected_node == "":
             return "No Edge Selected"

--- a/src/dgipy/network_graph.py
+++ b/src/dgipy/network_graph.py
@@ -1,5 +1,5 @@
 """Provides functionality to create networkx graphs and pltoly figures for network visualization"""
-from typing import List, Dict
+from typing import Dict, List
 
 import networkx as nx
 import pandas as pd

--- a/src/dgipy/network_graph.py
+++ b/src/dgipy/network_graph.py
@@ -1,4 +1,6 @@
 """Provides functionality to create networkx graphs and pltoly figures for network visualization"""
+from typing import List, Dict
+
 import networkx as nx
 import pandas as pd
 import plotly.graph_objects as go
@@ -6,7 +8,7 @@ import plotly.graph_objects as go
 PLOTLY_SEED = 7
 
 
-def __initalize_network(interactions: pd.DataFrame, selected_genes: list) -> nx.Graph:
+def __initalize_network(interactions: pd.DataFrame, selected_genes: List) -> nx.Graph:
     interactions_graph = nx.Graph()
     graphed_genes = set()
     for index in interactions.index:
@@ -47,7 +49,7 @@ def __add_node_attributes(interactions_graph: nx.Graph) -> None:
         interactions_graph.nodes[node]["node_size"] = set_size
 
 
-def create_network(interactions: pd.DataFrame, selected_genes: list) -> nx.Graph:
+def create_network(interactions: pd.DataFrame, selected_genes: List) -> nx.Graph:
     """Create a networkx graph representing interactions between genes and drugs
 
     :param interactions: DataFrame containing drug-gene interaction data
@@ -87,7 +89,7 @@ def generate_plotly(graph: nx.Graph) -> go.Figure:
     return fig
 
 
-def __create_trace_nodes(graph: nx.Graph, pos: dict) -> list:
+def __create_trace_nodes(graph: nx.Graph, pos: Dict) -> List:
     nodes_by_group = {
         "cyan": {
             "node_x": [],
@@ -153,7 +155,7 @@ def __create_trace_nodes(graph: nx.Graph, pos: dict) -> list:
     return trace_nodes
 
 
-def __create_trace_edges(graph: nx.Graph, pos: dict) -> go.Scatter:
+def __create_trace_edges(graph: nx.Graph, pos: Dict) -> go.Scatter:
     edge_x = []
     edge_y = []
 
@@ -197,7 +199,7 @@ def __create_trace_edges(graph: nx.Graph, pos: dict) -> go.Scatter:
     return trace_edges, i_trace_edges
 
 
-def generate_json(graph: nx.Graph) -> dict:
+def generate_json(graph: nx.Graph) -> Dict:
     """Generate a JSON representation of a networkx graph
 
     :param graph: networkx graph to be formatted as a JSON


### PR DESCRIPTION
I actually really like the `List | str` syntax myself (it's typescripty!), but it's not supported by some still-undeprecated versions of Python, so we're probably better off using the older style for now.